### PR TITLE
Immediately re-search at full window when LMR fails high

### DIFF
--- a/src/alpha_beta.rs
+++ b/src/alpha_beta.rs
@@ -157,11 +157,18 @@ pub fn alpha_beta<const PV_NODE: bool>(
             // Since the TT move, if existant, is in first place anyway this automatically includes information from shallower search depths
             eval = -alpha_beta::<true>(depth - 1, -beta, -alpha, sd, ply + 1, true);
         } else {
-            #[allow(clippy::useless_let_if_seq)]
             let mut reduction = 1;
             if settings::LMR && moves_visited >= settings::MOVES_BEFORE_LMR && depth > 2 {
+                reduction += LMR_REDUCTION[depth.clamp(0, 63)][moves_visited.clamp(0, 63)] >> 10;
+
+                // reduce less when in check
+                // reduce less on killers
+                // reduce less when OnPV
+                // reduce more on quiets
+                // reduce based on history score
+
                 // ensure we always reduce less than `depth`, otherwise we run into overflows and search until the end of the universe
-                reduction += LMR_REDUCTION[depth][moves_visited.clamp(0, 63)].min(depth as u32);
+                reduction = reduction.min(depth as u32);
             }
 
             debug_assert!(
@@ -179,13 +186,6 @@ pub fn alpha_beta<const PV_NODE: bool>(
             );
 
             if eval > alpha {
-                // If our shallow-depth search raised alpha, we perform a search at full depth but still with a null window
-                // in hopes that we can still avoid a full search
-                if reduction > 1 {
-                    // Search non-PV moves with null window
-                    sd.total_lmr_researches.fetch_add(1, Ordering::Relaxed);
-                    eval = -alpha_beta::<false>(depth - 1, -alpha - 1, -alpha, sd, ply + 1, true);
-                }
                 // ONLY do full-window full-depth re-searching if the current Node is on PV - we don't care for re-searching OffPV nodes
                 // (if they actually improve over the PV that variation will be searched again at the last PV node anyway)
                 if eval > alpha && PV_NODE {
@@ -294,13 +294,15 @@ const LMR_REDUCTION: [[u32; 64]; 64] = {
     out
 };
 
-// TODO const-memoize this for O(1) lookup
+/// Calculate the base reduction for LMR
+/// The output is multiplied by 1024 so that later, domain-dependant changes to the depth reduction can be applied
+/// with integer arithmetic
 const fn lmr_reduction(depth: usize, moves_visited: usize) -> u32 {
     // let r: u32 = match is_quiet {
     //     false => 20 * int_ln(depth) * int_ln(moves_visited) / 335,
     //     true => 135 * int_ln(depth) * int_ln(moves_visited) / 275
     // };
-    135 * int_ln(depth) * int_ln(moves_visited) / 275
+    (135 * int_ln(depth) * int_ln(moves_visited) / 275) << 10
 }
 
 #[allow(

--- a/src/iterative_deepening.rs
+++ b/src/iterative_deepening.rs
@@ -38,8 +38,7 @@ pub fn iterative_deepening(
             println!("AB Nodes: Nodes visited in standard Alpha-Beta");
             println!("QS nodes: Nodes visited in Quiescence search");
             println!("TT Hits : Times a TT entry was reused");
-            println!("LMR Res : Total Late Move Reduction re-searches");
-            println!("PVS Res : Total Principal Variation Search re-searches");
+            println!("Retries : Total re-searches (triggered by either PVS or LMR)");
             println!("GlobTime: Total elapsed time since search started (ms)");
             println!(
                 "EBF     : Effective Branch Factor (Relative to the previous depth iteration)"
@@ -64,7 +63,7 @@ pub fn iterative_deepening(
         }
 
         println!(
-            "{:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} PV",
+            "{:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} PV",
             "Depth",
             "Seldepth",
             "Score",
@@ -75,8 +74,7 @@ pub fn iterative_deepening(
             "AB Nodes",
             "QS Nodes",
             "TT Hits",
-            "LMR Res",
-            "PVS Res",
+            "Retries",
             "GlobTime",
             "EBF",
             "AB EBF"
@@ -171,7 +169,6 @@ pub fn iterative_deepening(
         #[allow(clippy::cast_precision_loss)]
         if debug {
             let iteration_tt_hits = iteration_search_data.total_tt_hits.load(Ordering::Relaxed);
-            let iteration_lmr_researches = iteration_search_data.total_lmr_researches.load(Ordering::Relaxed);
             let iteration_pvs_researches = iteration_search_data.total_pvs_researches.load(Ordering::Relaxed);
             let global_duration = global_start.elapsed();
 
@@ -192,7 +189,7 @@ pub fn iterative_deepening(
             };
 
             println!(
-                "{:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {}",
+                "{:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {:>8} {}",
                 depth,
                 seldepth,
                 best_eval_overall,
@@ -203,7 +200,6 @@ pub fn iterative_deepening(
                 format_usize(iteration_ab_nodes),
                 format_usize(iteration_qs_nodes),
                 format_usize(iteration_tt_hits),
-                format_usize(iteration_lmr_researches),
                 format_usize(iteration_pvs_researches),
                 format_usize(global_duration.as_millis() as usize),
                 format_f64(ebf),

--- a/src/types/search_data.rs
+++ b/src/types/search_data.rs
@@ -22,7 +22,6 @@ pub struct SharedSearchData<'sd> {
     pub total_qs_nodes: AtomicUsize,
     pub total_eval_nodes: AtomicUsize,
     pub total_tt_hits: AtomicUsize,
-    pub total_lmr_researches: AtomicUsize,
     pub total_pvs_researches: AtomicUsize,
     // stores whether the current search got cancelled due to timeout
     // TODO find out whether this can be eliminated in favor of using only `stop`
@@ -47,7 +46,6 @@ impl<'sd> SharedSearchData<'sd> {
             total_qs_nodes: AtomicUsize::new(0),
             total_eval_nodes: AtomicUsize::new(0),
             total_tt_hits: AtomicUsize::new(0),
-            total_lmr_researches: AtomicUsize::new(0),
             total_pvs_researches: AtomicUsize::new(0),
         }
     }


### PR DESCRIPTION
This massively reduces the search time at a given depth locally I refuse to believe it doesn't gain
(it's probably an issue of time control because 4+04 doesn't care if you get 2 nodes deeper in 2 seconds)